### PR TITLE
fix: use message-content estimate for context meter instead of cumulative session counters

### DIFF
--- a/hermes-ui.html
+++ b/hermes-ui.html
@@ -2842,10 +2842,11 @@ function estimateMessageTokens(messages) {
 }
 
 function getContextPressure(messages, sessionTokens) {
-  var input = Number(sessionTokens && sessionTokens.input) || 0;
-  var output = Number(sessionTokens && sessionTokens.output) || 0;
-  var exactTotal = input + output;
-  var estimatedTotal = exactTotal || estimateMessageTokens(messages);
+  // Always estimate from current messages — session input_tokens/output_tokens
+  // are cumulative across all API calls in the session's lifetime and don't
+  // reflect the actual current context size, especially with prompt caching.
+  var estimatedTotal = estimateMessageTokens(messages);
+  var exactTotal = (Number(sessionTokens && sessionTokens.input) || 0) + (Number(sessionTokens && sessionTokens.output) || 0);
   var workingBudget = 128000;
   var percent = Math.min(100, Math.round((estimatedTotal / workingBudget) * 100));
   var level = 'low';
@@ -2853,10 +2854,9 @@ function getContextPressure(messages, sessionTokens) {
   if (percent >= 90) { level = 'full'; label = 'Full'; }
   else if (percent >= 62) { level = 'high'; label = 'High'; }
   else if (percent >= 25) { level = 'medium'; label = 'Med'; }
-  var source = exactTotal ? 'usage data' : 'text estimate';
-  var title = 'Context ' + label + ': ' + compactTokenCount(estimatedTotal) + ' tokens, about ' + percent + '% of a 128k working budget (' + source + ')';
-  if (exactTotal) {
-    title += ' - ' + compactTokenCount(input) + ' in / ' + compactTokenCount(output) + ' out';
+  var title = 'Context ' + label + ': ' + compactTokenCount(estimatedTotal) + ' tokens, about ' + percent + '% of 128k working budget';
+  if (exactTotal > 0) {
+    title += ' (cumulative session: ' + compactTokenCount(exactTotal) + ')';
   }
   return { total: estimatedTotal, percent: percent, level: level, label: label, title: title };
 }


### PR DESCRIPTION
The context meter in the status bar was using cumulative `sessionPromptTokens` / `sessionCompletionTokens` as its primary data source. These counters sum *all* API calls across the session's lifetime and grow unbounded — especially with prompt caching, they can reach millions of tokens while the current conversation is only a few hundred.

This means the context bar shows "Full" after a few hours of use for every model, regardless of actual context pressure.

**Fix:** Always estimate from the current conversation messages via the existing `estimateMessageTokens()` character-based fallback. The cumulative session counter is still shown in the tooltip for reference.

`workingBudget` stays at 128K (the existing default) — that's a separate discussion left for model-specific tuning.