### PR TITLE
Fix compact conversation hydration and save races

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Built as a single-file HTML application with React 18, Hermes UI provides a full
 - **Sidebar history stays compact** — the browser stores chat metadata instead of full transcripts, avoiding localStorage and tab-memory blowups on large histories
 - **Chats hydrate on demand** — opening a chat loads its full transcript from the local server so refreshes do not pull every conversation into the browser at once
 - **Refresh races are guarded** — compact or partial browser saves can no longer overwrite full server-side chat mirrors during startup
+- **Update button handles release checkouts** — Update & Full Restart can now advance Hermes UI itself when the local install is checked out at an older release tag
 - **Stress coverage added** — browser tests now cover refreshing with large chat lists and switching into an inactive compact chat
 
 ## What's new in v3.3.24

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Built as a single-file HTML application with React 18, Hermes UI provides a full
 
 ---
 
+## What's new in v3.3.25
+
+**Large chat recovery and browser memory**
+- **Sidebar history stays compact** — the browser stores chat metadata instead of full transcripts, avoiding localStorage and tab-memory blowups on large histories
+- **Chats hydrate on demand** — opening a chat loads its full transcript from the local server so refreshes do not pull every conversation into the browser at once
+- **Refresh races are guarded** — compact or partial browser saves can no longer overwrite full server-side chat mirrors during startup
+- **Stress coverage added** — browser tests now cover refreshing with large chat lists and switching into an inactive compact chat
+
 ## What's new in v3.3.24
 
 **Workspace and updater polish**

--- a/hermes-ui.html
+++ b/hermes-ui.html
@@ -3906,8 +3906,15 @@ function compareConversationsByActivity(a, b) {
   return String(b && b.id || '').localeCompare(String(a && a.id || ''));
 }
 
-function conversationMessageStats(messages) {
+function conversationMessageStats(messages, fallback) {
   var list = Array.isArray(messages) ? messages : [];
+  if (!list.length && fallback) {
+    return {
+      message_count: Number(fallback.message_count || 0),
+      user_prompt_count: Number(fallback.user_prompt_count || 0),
+      tool_call_count: Number(fallback.tool_call_count || 0),
+    };
+  }
   return {
     message_count: list.length,
     user_prompt_count: list.filter(function(m) { return m && m.role === 'user'; }).length,
@@ -3920,8 +3927,8 @@ function mergeDuplicateConversation(a, b) {
   if (!b) return a;
   var aMsgs = Array.isArray(a.messages) ? a.messages : [];
   var bMsgs = Array.isArray(b.messages) ? b.messages : [];
-  var aStats = conversationMessageStats(aMsgs);
-  var bStats = conversationMessageStats(bMsgs);
+  var aStats = conversationMessageStats(aMsgs, a);
+  var bStats = conversationMessageStats(bMsgs, b);
   var bBetter = bStats.user_prompt_count > aStats.user_prompt_count
     || (bStats.user_prompt_count === aStats.user_prompt_count && bStats.message_count > aStats.message_count)
     || (bStats.user_prompt_count === aStats.user_prompt_count && bStats.message_count === aStats.message_count && getConversationActivityTime(b) > getConversationActivityTime(a));
@@ -3939,7 +3946,7 @@ function mergeDuplicateConversation(a, b) {
   if (getConversationActivityTime(secondary) > getConversationActivityTime(primary)) {
     primary.last_active_at = secondary.last_active_at || secondary.updated_at || primary.last_active_at;
   }
-  return Object.assign(primary, conversationMessageStats(primary.messages || []));
+  return Object.assign(primary, conversationMessageStats(primary.messages || [], primary));
 }
 
 function dedupeConversations(list) {
@@ -4039,6 +4046,22 @@ function cleanLoadedConversationMessages(messages) {
     return Object.assign({}, m, { streaming: false, thinking: false });
   }).filter(Boolean);
   return mergeToolOnlyAssistantRows(cleaned);
+}
+
+function compactConversationForBrowserCache(conv) {
+  if (!conv || typeof conv !== 'object') return conv;
+  var messages = Array.isArray(conv.messages) ? conv.messages : [];
+  var out = { ...conv };
+  out.message_count = Number.isFinite(out.message_count) ? out.message_count : messages.length;
+  out.user_prompt_count = Number.isFinite(out.user_prompt_count)
+    ? out.user_prompt_count
+    : messages.filter(function(m) { return m && m.role === 'user'; }).length;
+  out.tool_call_count = Number.isFinite(out.tool_call_count)
+    ? out.tool_call_count
+    : messages.reduce(function(sum, m) { return sum + ((m && m.toolCalls) ? m.toolCalls.length : 0); }, 0);
+  out.messages = [];
+  out._messages_compact = messages.length > 0 || !!conv._messages_compact;
+  return out;
 }
 
 function messagesForServerRepair(messages) {
@@ -9179,6 +9202,58 @@ function App() {
     }
   };
 
+  const loadConversationMessages = async function(convId, options) {
+    var opts = options || {};
+    if (!convId) return null;
+    var existing = (conversationsRef.current || []).find(function(c) { return c.id === convId; });
+    if (!opts.force && existing && Array.isArray(existing.messages) && existing.messages.length && !existing._messages_compact) {
+      return existing;
+    }
+    try {
+      var res = await fetch(API_BASE + '/api/ui-conversation?id=' + encodeURIComponent(convId), { cache: 'no-store' });
+      if (!res.ok) return existing || null;
+      var loaded = await res.json();
+      if (!loaded || !Array.isArray(loaded.messages)) return existing || null;
+      loaded.messages = cleanLoadedConversationMessages(loaded.messages);
+      loaded._messages_compact = false;
+      setConversations(function(prev) {
+        var found = false;
+        var next = prev.map(function(c) {
+          if (c.id !== convId) return c;
+          found = true;
+          return Object.assign({}, c, loaded);
+        });
+        return found ? next : [loaded].concat(prev);
+      });
+      return Object.assign({}, existing || {}, loaded);
+    } catch(e) {
+      console.warn('[hermes-ui] Failed to load conversation messages:', e);
+      return existing || null;
+    }
+  };
+
+  useEffect(function() {
+    if (!activeConvId) return;
+    if ((messagesRef.current || []).length > 0) return;
+    var conv = (conversationsRef.current || []).find(function(c) { return c.id === activeConvId; });
+    if (!conv) return;
+    var needsHydration = !!(
+      conv._messages_compact
+      || Number(conv.message_count || 0) > 0
+      || Number(conv.user_prompt_count || 0) > 0
+    );
+    if (!needsHydration) return;
+    var cancelled = false;
+    loadConversationMessages(activeConvId).then(function(loaded) {
+      if (cancelled) return;
+      if (activeConvRef.current !== activeConvId) return;
+      if (loaded && Array.isArray(loaded.messages) && loaded.messages.length && (messagesRef.current || []).length === 0) {
+        setMessages(loaded.messages);
+      }
+    });
+    return function() { cancelled = true; };
+  }, [activeConvId, conversations.length]);
+
   // Helper: update messages for a specific session, even if the user has switched away.
   // If the session is still active, updates messages state (fast, visible immediately).
   // If the user switched to a different chat, writes to the conversations array instead
@@ -10790,7 +10865,7 @@ function App() {
     }
   };
 
-  const selectConversation = (convId, options) => {
+  const selectConversation = async (convId, options) => {
     var searchJump = options && Number.isInteger(options.messageIndex)
       ? { messageIndex: options.messageIndex }
       : null;
@@ -10818,10 +10893,20 @@ function App() {
         })
       );
     }
-    // 2. Load target conversation's messages from the ref (always fresh)
-    const targetConv = conversationsRef.current.find(c => c.id === convId);
-    setMessages((targetConv && targetConv.messages) || []);
     setActiveConvId(convId);
+    // 2. Load target conversation's messages on demand. The sidebar list is
+    // compact so refreshes do not hydrate every transcript into browser RAM.
+    // Mark the target active first, then force-load exactly that transcript so
+    // compact rows cannot render as an empty chat after a fast sidebar switch.
+    const targetMeta = (conversationsRef.current || []).find(function(c) { return c.id === convId; });
+    if (!targetMeta || targetMeta._messages_compact || !(targetMeta.messages || []).length) {
+      setMessages([]);
+    } else {
+      setMessages(targetMeta.messages || []);
+    }
+    const targetConv = await loadConversationMessages(convId, { force: true });
+    if (activeConvRef.current !== convId) return;
+    setMessages((targetConv && targetConv.messages) || []);
     if (targetConv && targetConv.workspace) switchWorkspace(targetConv.workspace, { skipConversationUpdate: true });
     setConversations(prev => prev.map(c => c.id === convId ? Object.assign({}, c, { unread_count: 0 }) : c));
     setInput('');
@@ -10888,10 +10973,11 @@ function App() {
         if (saved) localConvs = JSON.parse(saved);
       } catch(e) {}
 
-      // Always fetch from server — use whichever has more conversations
+      // Always fetch compact server metadata. Full message bodies are loaded
+      // only for the active/selected chat to avoid browser OOM on refresh.
       var serverConvs = [];
       try {
-        const res = await fetch('/api/ui-conversations', { cache: 'no-store' });
+        const res = await fetch('/api/ui-conversations?compact=1', { cache: 'no-store' });
         if (res.ok) serverConvs = await res.json();
       } catch(e) {}
 
@@ -10922,7 +11008,14 @@ function App() {
           if (conv) {
             _setActiveConvId(savedId);
             activeConvRef.current = savedId;
-            setMessages(conv.messages || []);
+            if (conv.messages && conv.messages.length && !conv._messages_compact) {
+              setMessages(conv.messages || []);
+            } else {
+              setMessages([]);
+              loadConversationMessages(savedId).then(function(loaded) {
+                if (activeConvRef.current === savedId && loaded) setMessages(loaded.messages || []);
+              });
+            }
             if (conv.workspace) switchWorkspace(conv.workspace, { skipConversationUpdate: true });
           }
         }
@@ -10935,11 +11028,15 @@ function App() {
   useEffect(() => {
     if (conversations.length === 0) return;
     const toSave = sortConversationsByActivity(conversations).slice(0, 50);
-    // Save to localStorage
+    const browserCache = toSave.map(compactConversationForBrowserCache);
+    // Save compact metadata to localStorage. Full transcripts can exceed
+    // browser quota and crash the tab; the server remains the durable store.
     try {
-      localStorage.setItem('hermes-conversations', JSON.stringify(toSave));
-    } catch(e) {}
-    // Save to server (disk) so it survives browser data wipe
+      localStorage.setItem('hermes-conversations', JSON.stringify(browserCache));
+    } catch(e) {
+      console.warn('[hermes-ui] Compact conversation cache write failed:', e);
+    }
+    // Save full conversations to server (disk) so they survive browser data wipe
     try {
       fetch('/api/ui-conversations', {
         method: 'POST',

--- a/serve_lite.py
+++ b/serve_lite.py
@@ -419,7 +419,7 @@ def _set_last_workspace(path):
 # Current hermes-ui release version. Bump on every tagged release so the
 # /api/version endpoint can tell the UI when a newer release is available on
 # GitHub. Keep in sync with the git tag (e.g. "3.3" corresponds to v3.3).
-__version__ = "3.3.24"
+__version__ = "3.3.25"
 _GITHUB_RELEASES_API = "https://api.github.com/repos/pyrate-llama/hermes-ui/releases/latest"
 _GITHUB_TAGS_API = "https://api.github.com/repos/pyrate-llama/hermes-ui/tags?per_page=30"
 _GITHUB_TAG_URL = "https://github.com/pyrate-llama/hermes-ui/releases/tag/{tag}"

--- a/serve_lite.py
+++ b/serve_lite.py
@@ -2134,6 +2134,53 @@ def _ui_conversation_message_stats(messages):
     }
 
 
+def _compact_ui_conversation_entry(entry):
+    """Return sidebar metadata without the full message body.
+
+    The browser only needs counts/title/activity for the conversation list.
+    Full message arrays can be multi-megabyte and are loaded on demand when a
+    chat is opened.
+    """
+    if not isinstance(entry, dict):
+        return entry
+    messages = entry.get("messages") if isinstance(entry.get("messages"), list) else []
+    out = {
+        k: v for k, v in entry.items()
+        if k not in ("messages", "toolCalls", "reasoning", "activityLog")
+    }
+    stats = _ui_conversation_message_stats(messages)
+    for key, value in stats.items():
+        if out.get(key) is None or stats[key] > int(out.get(key) or 0):
+            out[key] = value
+    out["messages"] = []
+    out["_messages_compact"] = bool(messages)
+    return out
+
+
+def _merge_compact_ui_entry_with_existing(incoming, existing):
+    """Preserve existing full messages when browser posts compact metadata."""
+    if not isinstance(incoming, dict) or not isinstance(existing, dict):
+        return incoming
+    incoming_msgs = incoming.get("messages") if isinstance(incoming.get("messages"), list) else []
+    existing_msgs = existing.get("messages") if isinstance(existing.get("messages"), list) else []
+    looks_compact = bool(
+        incoming.get("_messages_compact")
+        or int(incoming.get("message_count") or 0) > 0
+        or int(incoming.get("user_prompt_count") or 0) > 0
+    )
+    if incoming_msgs or not existing_msgs or not looks_compact:
+        return incoming
+    out = dict(existing)
+    for key, value in incoming.items():
+        if key in ("messages", "_messages_compact"):
+            continue
+        out[key] = value
+    out["messages"] = existing_msgs
+    out["_messages_compact"] = False
+    out.update(_ui_conversation_message_stats(existing_msgs))
+    return out
+
+
 def _better_ui_conversation_entry(a, b):
     """Merge two sidebar entries with the same id, preferring fuller content."""
     if not isinstance(a, dict):
@@ -2404,6 +2451,7 @@ os.makedirs(SESSION_DIR, exist_ok=True)
 SESSION_ALIASES_FILE = os.path.join(HERMES_HOME, "hermes-ui", "session-aliases.json")
 WORK_ITEMS_FILE = os.path.join(HERMES_HOME, "hermes-ui", "work-items.json")
 UI_CONVERSATIONS_FILE = os.path.join(HERMES_HOME, "ui-conversations.json")
+UI_CONVERSATIONS_LOCK = threading.RLock()
 WORK_ITEM_DONE_RETENTION_SEC = 2 * 60 * 60
 WORK_ITEM_BLOCKED_RETENTION_SEC = 12 * 60 * 60
 STREAM_STATUS_RETENTION_SEC = 10 * 60
@@ -4399,6 +4447,9 @@ class HermesDirectServer(http.server.SimpleHTTPRequestHandler):
         stale tab, etc.) is therefore recoverable on next page load
         without manual intervention.
         """
+        qs = urllib.parse.urlparse(self.path).query
+        params = urllib.parse.parse_qs(qs)
+        compact = str((params.get("compact") or [""])[0]).lower() in ("1", "true", "yes")
         try:
             data = json.load(open(self.CONV_PATH)) if os.path.exists(self.CONV_PATH) else []
             if not isinstance(data, list):
@@ -4459,7 +4510,44 @@ class HermesDirectServer(http.server.SimpleHTTPRequestHandler):
             except Exception as e:
                 print(f"[serve] /api/ui-conversations dedupe persist failed: {e}", flush=True)
 
+        if compact:
+            return self._json([_compact_ui_conversation_entry(entry) for entry in data])
         self._json(data)
+
+    def _conversation_load_one(self):
+        """GET /api/ui-conversation?id=... — full messages for one chat."""
+        qs = urllib.parse.urlparse(self.path).query
+        params = urllib.parse.parse_qs(qs)
+        session_id = (params.get("id") or params.get("session_id") or [""])[0]
+        session_id = str(session_id or "").strip()
+        if not session_id:
+            return self._json({"error": "missing id"}, 400)
+
+        entry = None
+        try:
+            data = json.load(open(self.CONV_PATH)) if os.path.exists(self.CONV_PATH) else []
+            if isinstance(data, list):
+                for item in data:
+                    if isinstance(item, dict) and str(item.get("id") or "") == session_id:
+                        entry = item
+                        break
+        except Exception:
+            entry = None
+
+        backend_path = os.path.join(SESSION_DIR, session_id + ".json") if SESSION_DIR else None
+        if backend_path and os.path.isfile(backend_path):
+            if entry:
+                entry = _reconcile_ui_entry_with_backend(entry, backend_path)
+            else:
+                entry = _backend_session_to_ui_entry(session_id, backend_path)
+
+        if not entry:
+            return self._json({"error": "conversation not found"}, 404)
+
+        stats = _ui_conversation_message_stats(entry.get("messages") or [])
+        out = dict(entry)
+        out.update(stats)
+        return self._json(out)
 
     def _conversations_save(self):
         """POST /api/ui-conversations — defensive.
@@ -4471,6 +4559,7 @@ class HermesDirectServer(http.server.SimpleHTTPRequestHandler):
         backend session file is gone) flow through normally.
         """
         body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        UI_CONVERSATIONS_LOCK.acquire()
         try:
             incoming = json.loads(body) if body else []
             if not isinstance(incoming, list):
@@ -4486,6 +4575,28 @@ class HermesDirectServer(http.server.SimpleHTTPRequestHandler):
             incoming = _dedupe_ui_conversations(incoming)
             incoming_deduped = incoming_before_dedupe - len(incoming)
             existing = _dedupe_ui_conversations(existing)
+            existing_by_id = {
+                str(entry.get("id")): entry
+                for entry in existing
+                if isinstance(entry, dict) and entry.get("id")
+            }
+            suspicious_partial_write = bool(
+                len(existing) >= 10
+                and len(incoming) < max(5, int(len(existing) * 0.75))
+            )
+
+            # Browser localStorage intentionally posts compact rows to avoid
+            # quota/OOM failures.  Never let those compact rows overwrite the
+            # server's full UI mirror for chats that do not have a backend
+            # session file to rebuild from.
+            compact_preserved = 0
+            for i, entry in enumerate(incoming):
+                if not isinstance(entry, dict):
+                    continue
+                merged = _merge_compact_ui_entry_with_existing(entry, existing_by_id.get(str(entry.get("id"))))
+                if merged is not entry:
+                    incoming[i] = merged
+                    compact_preserved += 1
 
             # Pass A: backfill any incoming entry whose backend file has
             # newer turns than the UI sent.  Same drift that the GET
@@ -4517,28 +4628,38 @@ class HermesDirectServer(http.server.SimpleHTTPRequestHandler):
                 sid = entry.get("id")
                 if not sid or sid in incoming_ids:
                     continue
-                if _backend_session_exists(sid):
+                if _backend_session_exists(sid) or suspicious_partial_write:
                     incoming.append(entry)
                     preserved += 1
 
             if preserved:
                 incoming = _dedupe_ui_conversations(incoming)
 
-            if preserved or backfilled or incoming_deduped:
+            if preserved or backfilled or incoming_deduped or compact_preserved:
                 incoming.sort(
                     key=lambda c: (c.get("last_active_at") or "") if isinstance(c, dict) else "",
                     reverse=True,
                 )
                 print(
                     f"[serve] /api/ui-conversations POST: preserved={preserved} "
-                    f"backfilled={backfilled} deduped={incoming_deduped}",
+                    f"backfilled={backfilled} deduped={incoming_deduped} "
+                    f"compact_preserved={compact_preserved} "
+                    f"suspicious_partial_write={suspicious_partial_write}",
                     flush=True,
                 )
 
             json.dump(incoming, open(self.CONV_PATH, "w"), indent=2)
-            self._json({"ok": True, "preserved": preserved, "backfilled": backfilled, "deduped": incoming_deduped})
+            self._json({
+                "ok": True,
+                "preserved": preserved,
+                "backfilled": backfilled,
+                "deduped": incoming_deduped,
+                "compact_preserved": compact_preserved,
+            })
         except Exception as e:
             self._json({"error": str(e)}, 500)
+        finally:
+            UI_CONVERSATIONS_LOCK.release()
 
     # ── Spaces / workspaces ──
     def _workspaces_load(self):
@@ -5608,8 +5729,10 @@ class HermesDirectServer(http.server.SimpleHTTPRequestHandler):
             self._handle_chat_stream()
         elif self.path.startswith("/api/chat/cancel"):
             self._handle_cancel()
-        elif self.path == "/api/ui-conversations":
+        elif self.path == "/api/ui-conversations" or self.path.startswith("/api/ui-conversations?"):
             self._conversations_load()
+        elif self.path.startswith("/api/ui-conversation"):
+            self._conversation_load_one()
         elif self.path == "/api/workspaces":
             self._workspaces_load()
         elif self.path.startswith("/api/workspaces/browse"):

--- a/serve_lite.py
+++ b/serve_lite.py
@@ -5902,12 +5902,58 @@ class HermesDirectServer(http.server.SimpleHTTPRequestHandler):
                 return tag
         return ""
 
+    def _latest_ui_release_tag(self, ui_dir):
+        ok, out = self._run_git(
+            ui_dir,
+            ["tag", "--list", "v[0-9]*", "--sort=-version:refname"],
+            timeout=20,
+        )
+        if not ok:
+            return ""
+        for line in out.splitlines():
+            tag = line.strip()
+            if re.match(r"^v\d+(?:\.\d+){1,3}$", tag):
+                return tag
+        return ""
+
+    def _update_ui_repo(self, ui_dir):
+        if not os.path.isdir(os.path.join(ui_dir, ".git")):
+            return False, f"error: {ui_dir} is not a git checkout"
+
+        steps = []
+        ok, out = self._run_git(ui_dir, ["fetch", "--tags", "--force", "origin"], timeout=90)
+        steps.append(f"fetch tags: {out}")
+        if not ok:
+            return False, "\n".join(steps)
+
+        on_branch, branch = self._run_git(ui_dir, ["symbolic-ref", "-q", "--short", "HEAD"], timeout=10)
+        branch = branch.strip() if on_branch else ""
+        if branch:
+            ok, out = self._run_git(ui_dir, ["pull", "--ff-only"], timeout=90)
+            steps.append(f"pull {branch}: {out}")
+            return ok, "\n".join(steps)
+
+        latest_tag = self._latest_ui_release_tag(ui_dir)
+        if not latest_tag:
+            steps.append("error: no release tag found after fetch")
+            return False, "\n".join(steps)
+
+        _, current_tag = self._run_git(ui_dir, ["describe", "--tags", "--exact-match"], timeout=10)
+        current_tag = current_tag.strip()
+        if current_tag == latest_tag:
+            steps.append(f"already on latest release tag {latest_tag}")
+            return True, "\n".join(steps)
+
+        ok, out = self._run_git(ui_dir, ["checkout", latest_tag], timeout=60)
+        steps.append(f"checkout {latest_tag}: {out}")
+        return ok, "\n".join(steps)
+
     def _update_agent_repo(self, agent_dir):
         if not os.path.isdir(os.path.join(agent_dir, ".git")):
             return False, f"error: {agent_dir} is not a git checkout"
 
         steps = []
-        ok, out = self._run_git(agent_dir, ["fetch", "--tags", "origin"], timeout=90)
+        ok, out = self._run_git(agent_dir, ["fetch", "--tags", "--force", "origin"], timeout=90)
         steps.append(f"fetch tags: {out}")
         if not ok:
             return False, "\n".join(steps)
@@ -5964,7 +6010,7 @@ class HermesDirectServer(http.server.SimpleHTTPRequestHandler):
         outputs = []
         all_ok = True
 
-        ok, out = self._run_git(ui_dir, ["pull", "--ff-only"], timeout=60)
+        ok, out = self._update_ui_repo(ui_dir)
         all_ok = all_ok and ok
         outputs.append(f"hermes-ui: {out if ok else 'error: ' + out}")
 

--- a/tests/browser_conversation_compaction.py
+++ b/tests/browser_conversation_compaction.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Verify large conversation lists hydrate compactly in the browser."""
+
+import contextlib
+import json
+import os
+import pathlib
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+
+from playwright.sync_api import sync_playwright
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def free_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def wait_for_server(url, process, timeout=20):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError("serve_lite.py exited before test connected")
+        try:
+            with urllib.request.urlopen(url, timeout=1) as response:
+                if response.status == 200:
+                    return
+        except Exception:
+            time.sleep(0.1)
+    raise TimeoutError(f"server did not become ready at {url}")
+
+
+def make_conversation(index, turns=120, chars=1400):
+    messages = []
+    for turn in range(turns):
+        messages.append({
+            "id": f"u-{index}-{turn}",
+            "role": "user",
+            "content": "prompt " + ("x" * chars),
+        })
+        messages.append({
+            "id": f"a-{index}-{turn}",
+            "role": "assistant",
+            "content": "reply " + ("y" * chars),
+        })
+    return {
+        "id": f"compact-{index}",
+        "title": f"Compact stress {index}",
+        "created": "6/24/2026, 12:00:00 AM",
+        "last_active_at": f"2026-06-24T07:{index % 60:02d}:00Z",
+        "messages": messages,
+        "message_count": len(messages),
+        "user_prompt_count": turns,
+        "tool_call_count": 0,
+    }
+
+
+def main():
+    port = free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    with tempfile.TemporaryDirectory(prefix="hermes-ui-compact-test-") as home:
+        env = os.environ.copy()
+        env["HOME"] = home
+        for key in tuple(env):
+            if key.endswith("_API_KEY") or key.endswith("_TOKEN"):
+                env.pop(key, None)
+
+        process = subprocess.Popen(
+            [sys.executable, "serve_lite.py", "--port", str(port)],
+            cwd=ROOT,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        try:
+            wait_for_server(f"{base_url}/health", process)
+            payload = [make_conversation(i) for i in range(50)]
+            raw = json.dumps(payload).encode("utf-8")
+            req = urllib.request.Request(
+                f"{base_url}/api/ui-conversations",
+                data=raw,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            urllib.request.urlopen(req, timeout=60).read()
+
+            compact = json.loads(
+                urllib.request.urlopen(
+                    f"{base_url}/api/ui-conversations?compact=1",
+                    timeout=60,
+                ).read().decode("utf-8")
+            )
+            if len(json.dumps(compact).encode("utf-8")) >= 100_000:
+                raise AssertionError("compact conversation list is unexpectedly large")
+            if any(item.get("messages") for item in compact):
+                raise AssertionError("compact conversation list leaked message bodies")
+
+            with sync_playwright() as playwright:
+                browser = playwright.chromium.launch()
+                page = browser.new_page(viewport={"width": 1440, "height": 900})
+                page.add_init_script(
+                    """
+                    localStorage.setItem('hermes-ui-welcomed', '1');
+                    localStorage.setItem('hermes-active-session', 'compact-0');
+                    """
+                )
+                page.goto(f"{base_url}/hermes-ui.html", wait_until="domcontentloaded", timeout=120_000)
+                page.wait_for_selector(".app", timeout=120_000)
+                page.wait_for_timeout(2500)
+                metrics = page.evaluate(
+                    """() => {
+                      const saved = localStorage.getItem('hermes-conversations') || '';
+                      const convs = JSON.parse(saved || '[]');
+                      return {
+                        localStorageBytes: saved.length,
+                        sidebarItems: document.querySelectorAll('.conv-item').length,
+                        messageDom: document.querySelectorAll('.message').length,
+                        storedMessages: convs.reduce((sum, conv) => sum + (conv.messages || []).length, 0),
+                        firstCount: convs[0] && convs[0].message_count,
+                      };
+                    }"""
+                )
+                page.get_by_placeholder("Filter chats...").fill("Compact stress 7")
+                page.locator(".conv-item", has_text="Compact stress 7").click()
+                page.wait_for_timeout(5000)
+                switch_metrics = page.evaluate(
+                    """() => ({
+                      title: document.querySelector('.header-title')?.textContent || '',
+                      activeId: localStorage.getItem('hermes-active-session'),
+                      messageDom: document.querySelectorAll('.message').length,
+                    })"""
+                )
+                browser.close()
+
+            if metrics["localStorageBytes"] >= 100_000:
+                raise AssertionError(f"browser cache too large: {metrics}")
+            if metrics["storedMessages"] != 0:
+                raise AssertionError(f"browser cache retained messages: {metrics}")
+            if metrics["sidebarItems"] != 50:
+                raise AssertionError(f"sidebar did not hydrate compact rows: {metrics}")
+            if metrics["messageDom"] == 0:
+                raise AssertionError(f"active conversation did not load full messages: {metrics}")
+            if metrics["firstCount"] != 240:
+                raise AssertionError(f"compact row lost message count: {metrics}")
+            if switch_metrics["activeId"] != "compact-7" or switch_metrics["messageDom"] == 0:
+                raise AssertionError(f"inactive compact row did not hydrate on switch: {switch_metrics}")
+
+            # Simulate a returning user opening an inactive compact row after
+            # the browser has POSTed compact metadata back to the server.
+            full_after_compact_save = json.loads(
+                urllib.request.urlopen(
+                    f"{base_url}/api/ui-conversation?id=compact-7",
+                    timeout=60,
+                ).read().decode("utf-8")
+            )
+            if len(full_after_compact_save.get("messages") or []) != 240:
+                raise AssertionError("compact browser save overwrote inactive full messages")
+        finally:
+            process.terminate()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                process.wait(timeout=5)
+            if process.poll() is None:
+                process.kill()
+            output = process.stdout.read() if process.stdout else ""
+            if process.returncode not in (0, -15):
+                print(output, file=sys.stderr)
+
+    print("Browser compact conversation test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/browser_smoke.py
+++ b/tests/browser_smoke.py
@@ -79,6 +79,7 @@ def main():
                         f"{message.text} ({message.location.get('url', '')})"
                     )
                     if message.type == "error"
+                    and "deoptimised the styling of /Inline Babel script" not in message.text
                     else None,
                 )
                 page.on(

--- a/tests/update_repo_logic.py
+++ b/tests/update_repo_logic.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Regression tests for the in-UI update helpers."""
+
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import serve_lite  # noqa: E402
+
+
+def git(cwd, *args):
+    result = subprocess.run(
+        ["git", "-C", str(cwd)] + list(args),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return (result.stdout or "").strip()
+
+
+def commit_file(repo, path, text):
+    target = pathlib.Path(repo) / path
+    target.write_text(text, encoding="utf-8")
+    git(repo, "add", path)
+    git(repo, "commit", "-m", f"update {path}")
+
+
+def new_handler():
+    return object.__new__(serve_lite.HermesDirectServer)
+
+
+def main():
+    old_home = os.environ.get("HOME")
+    with tempfile.TemporaryDirectory(prefix="hermes-update-logic-") as tmp:
+        tmp_path = pathlib.Path(tmp)
+        os.environ["HOME"] = str(tmp_path / "home")
+
+        origin = tmp_path / "origin.git"
+        work = tmp_path / "work"
+        install = tmp_path / "install"
+        git(tmp_path, "init", "--bare", str(origin))
+        git(tmp_path, "clone", str(origin), str(work))
+        git(work, "config", "user.email", "test@example.invalid")
+        git(work, "config", "user.name", "Hermes Test")
+
+        commit_file(work, "serve_lite.py", "__version__ = '3.3.22'\n")
+        git(work, "tag", "v3.3.22")
+        commit_file(work, "serve_lite.py", "__version__ = '3.3.24'\n")
+        git(work, "tag", "v3.3.24")
+        git(work, "push", "--tags", "origin", "HEAD:main")
+
+        git(tmp_path, "clone", str(origin), str(install))
+        git(install, "checkout", "v3.3.22")
+        if git(install, "describe", "--tags", "--exact-match") != "v3.3.22":
+            raise AssertionError("test install did not start on v3.3.22")
+
+        ok, output = new_handler()._update_ui_repo(str(install))
+        if not ok:
+            raise AssertionError(output)
+        if git(install, "describe", "--tags", "--exact-match") != "v3.3.24":
+            raise AssertionError(f"detached release checkout did not update:\n{output}")
+
+        branch_install = tmp_path / "branch-install"
+        git(tmp_path, "clone", str(origin), str(branch_install))
+        commit_file(work, "serve_lite.py", "__version__ = '3.3.25'\n")
+        git(work, "tag", "v3.3.25")
+        git(work, "push", "--tags", "origin", "HEAD:main")
+
+        ok, output = new_handler()._update_ui_repo(str(branch_install))
+        if not ok:
+            raise AssertionError(output)
+        if git(branch_install, "rev-parse", "HEAD") != git(work, "rev-parse", "HEAD"):
+            raise AssertionError(f"branch checkout did not fast-forward:\n{output}")
+
+    if old_home is None:
+        os.environ.pop("HOME", None)
+    else:
+        os.environ["HOME"] = old_home
+
+    print("Update repo logic tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Store compact conversation metadata in browser localStorage instead of full transcripts.
- Add on-demand full transcript loading for active/selected chats.
- Harden the server conversation mirror against compact/partial stale writes and serialize UI conversation saves.
- Fix Update & Full Restart for Hermes UI installs checked out at older release tags, and force-refresh release tags during update.
- Add browser regression coverage for large conversation lists, refresh, and switching to an inactive compact chat, plus updater regression coverage for detached release installs.

## Verification
- python3 -m py_compile serve_lite.py tests/update_repo_logic.py tests/browser_conversation_compaction.py tests/browser_smoke.py
- python3 tests/update_repo_logic.py
- /tmp/hermes-ui-investigate-venv/bin/python tests/browser_conversation_compaction.py
- /tmp/hermes-ui-investigate-venv/bin/python tests/browser_smoke.py
- Heavy isolated stress run with ~53.5 MB seeded chat history: localStorage stayed ~11.5 KB, stored message bodies stayed 0, sidebar switch rendered messages, server retained all 520 messages for the selected chat.

Fixes #27