### PR TITLE
Fix Reasoning Notes memory growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Built as a single-file HTML application with React 18, Hermes UI provides a full
 
 ---
 
+## What's new in v3.3.26
+
+**Reasoning Notes memory safety**
+- **Reasoning streams stop ballooning** — cumulative reasoning snapshots are normalized into deltas before they reach the visible Reasoning Notes panel
+- **Live notes stay bounded** — long reasoning output is capped to the latest notes for display and storage, preventing unbounded browser RAM growth
+- **Streaming saves are lighter** — live reasoning notes no longer force full conversation mirror writes on every reasoning event; final transcript sync still preserves the completed turn
+- **Regression coverage added** — tests now cover cumulative reasoning snapshots so they do not append repeated full copies
+
 ## What's new in v3.3.25
 
 **Large chat recovery and browser memory**

--- a/hermes-ui.html
+++ b/hermes-ui.html
@@ -4868,6 +4868,51 @@ function buildTaskBoardItems(conversations, streamingSessionIds, agentStateBySes
   });
 }
 
+const MAX_REASONING_STORED_CHARS = 16000;
+const MAX_REASONING_RENDER_CHARS = 12000;
+
+function appendReasoningText(existing, chunk, maxChars) {
+  existing = String(existing || '');
+  chunk = String(chunk || '');
+  if (!chunk.trim()) return existing;
+  var addition = chunk;
+
+  // Some providers emit the full reasoning snapshot on every event rather
+  // than a delta. Treat prefix/overlap repeats as deltas so Reasoning Notes
+  // do not grow quadratically while streaming.
+  if (existing && chunk.indexOf(existing) === 0) {
+    addition = chunk.slice(existing.length);
+  } else if (existing && existing.endsWith(chunk)) {
+    addition = '';
+  } else if (existing && chunk) {
+    var maxOverlap = Math.min(existing.length, chunk.length, 4000);
+    for (var size = maxOverlap; size > 0; size--) {
+      if (existing.slice(existing.length - size) === chunk.slice(0, size)) {
+        addition = chunk.slice(size);
+        break;
+      }
+    }
+  }
+
+  if (!addition.trim()) return existing;
+  if (!existing) {
+    var first = addition.trimStart();
+    return first.length > maxChars ? first.slice(first.length - maxChars) : first;
+  }
+  var prevChar = existing.charAt(existing.length - 1);
+  var nextChar = addition.charAt(0);
+  var needsSpace = /[A-Za-z0-9)]/.test(prevChar) && /[A-Za-z0-9(]/.test(nextChar);
+  var combined = existing + (needsSpace ? ' ' : '') + addition;
+  return combined.length > maxChars ? combined.slice(combined.length - maxChars) : combined;
+}
+
+function formatReasoningTextForRender(text) {
+  text = String(text || '');
+  if (text.length <= MAX_REASONING_RENDER_CHARS) return text;
+  return '[showing latest reasoning notes; earlier notes were compacted]\n\n'
+    + text.slice(text.length - MAX_REASONING_RENDER_CHARS);
+}
+
 function TasksView({ conversations, streamingSessionIds, agentStateBySession, activeConvId, serverWorkItems, dismissedTaskItems, doneTaskItems, onOpenConversation, onDismissTask, onMarkTaskDone }) {
   var [filter, setFilter] = useState('');
   var items = useMemo(function() {
@@ -5091,9 +5136,10 @@ function MessageBubble({ message, onImageClick, onEdit, onRetry, index, highligh
     return !isTodoTool(tool);
   });
   var reasoningItems = Array.isArray(message.reasoning) ? message.reasoning : [];
-  var reasoningText = reasoningItems.map(function(item) {
+  var reasoningRawText = reasoningItems.map(function(item) {
     return typeof item === 'string' ? item : (item && item.text) || '';
   }).filter(Boolean).join('\n\n');
+  var reasoningText = formatReasoningTextForRender(reasoningRawText);
   var stoppedBeforeFollowup = messageNeedsFollowupAfterStopping(message);
   var showToollessWorkWarning = messageClaimsLocalWorkWithoutTools(message) || stoppedBeforeFollowup;
 
@@ -9258,13 +9304,15 @@ function App() {
   // If the session is still active, updates messages state (fast, visible immediately).
   // If the user switched to a different chat, writes to the conversations array instead
   // so the data is preserved and visible when they switch back.
-	  const updateStreamMessages = (sessionId, updater) => {
+	  const updateStreamMessages = (sessionId, updater, options) => {
+	    var opts = options || {};
 	    var isActiveSession = activeConvRef.current === sessionId;
 	    var nowIso = new Date().toISOString();
     if (activeConvRef.current === sessionId) {
       // Still viewing this conversation — update messages state normally
       setMessages(updater);
     }
+    if (opts.skipConversationUpdate) return;
     // Always persist to conversations array so switching back loads the latest
     setConversations(prev =>
       prev.map(c => {
@@ -11593,29 +11641,19 @@ function App() {
                 var last = updated[updated.length - 1];
                 if (last && last.role === 'assistant' && last.streaming) {
                   var nextReasoning = (last.reasoning || []).slice();
-                  var appendReasoningText = function(existing, chunk) {
-                    existing = String(existing || '');
-                    chunk = String(chunk || '');
-                    if (!chunk) return existing;
-                    if (!existing) return chunk.trimStart();
-                    var prevChar = existing.charAt(existing.length - 1);
-                    var nextChar = chunk.charAt(0);
-                    var needsSpace = /[A-Za-z0-9)]/.test(prevChar) && /[A-Za-z0-9(]/.test(nextChar);
-                    return existing + (needsSpace ? ' ' : '') + chunk;
-                  };
                   // Concatenate into a single entry instead of one-per-token.
                   if (reasoningNote.trim()) {
                     if (nextReasoning.length > 0) {
                       var lastEntry = nextReasoning[nextReasoning.length - 1];
-                      nextReasoning[nextReasoning.length - 1] = { ...lastEntry, text: appendReasoningText(lastEntry.text, reasoningNote) };
+                      nextReasoning[nextReasoning.length - 1] = { ...lastEntry, text: appendReasoningText(lastEntry.text, reasoningNote, MAX_REASONING_STORED_CHARS) };
                     } else {
-                      nextReasoning.push({ text: reasoningNote.trimStart(), timestamp: new Date().toISOString() });
+                      nextReasoning.push({ text: appendReasoningText('', reasoningNote, MAX_REASONING_STORED_CHARS), timestamp: new Date().toISOString() });
                     }
                   }
                   updated[updated.length - 1] = { ...last, thinking: true, reasoning: nextReasoning.slice(-24) };
                 }
                 return updated;
-              });
+              }, { skipConversationUpdate: true });
             }
           }
         },

--- a/serve_lite.py
+++ b/serve_lite.py
@@ -419,7 +419,7 @@ def _set_last_workspace(path):
 # Current hermes-ui release version. Bump on every tagged release so the
 # /api/version endpoint can tell the UI when a newer release is available on
 # GitHub. Keep in sync with the git tag (e.g. "3.3" corresponds to v3.3).
-__version__ = "3.3.25"
+__version__ = "3.3.26"
 _GITHUB_RELEASES_API = "https://api.github.com/repos/pyrate-llama/hermes-ui/releases/latest"
 _GITHUB_TAGS_API = "https://api.github.com/repos/pyrate-llama/hermes-ui/tags?per_page=30"
 _GITHUB_TAG_URL = "https://github.com/pyrate-llama/hermes-ui/releases/tag/{tag}"

--- a/tests/reasoning_notes_compaction.mjs
+++ b/tests/reasoning_notes_compaction.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import vm from 'node:vm';
+import assert from 'node:assert/strict';
+
+const html = fs.readFileSync(new URL('../hermes-ui.html', import.meta.url), 'utf8');
+const start = html.indexOf('const MAX_REASONING_STORED_CHARS');
+const end = html.indexOf('function TasksView', start);
+assert.ok(start > 0 && end > start, 'reasoning helpers not found');
+
+const sandbox = {};
+vm.createContext(sandbox);
+vm.runInContext(
+  html.slice(start, end) + '\nthis.appendReasoningText = appendReasoningText; this.formatReasoningTextForRender = formatReasoningTextForRender; this.MAX_REASONING_STORED_CHARS = MAX_REASONING_STORED_CHARS; this.MAX_REASONING_RENDER_CHARS = MAX_REASONING_RENDER_CHARS;',
+  sandbox,
+);
+
+let text = '';
+for (let i = 1; i <= 300; i += 1) {
+  const cumulative = Array.from({ length: i }, (_, j) => `step-${j + 1}`).join(' ');
+  text = sandbox.appendReasoningText(text, cumulative, sandbox.MAX_REASONING_STORED_CHARS);
+}
+assert.ok(text.includes('step-300'), 'latest cumulative reasoning should be retained');
+assert.ok(text.length <= sandbox.MAX_REASONING_STORED_CHARS, 'stored reasoning should be capped');
+assert.ok(!/step-299 step-1/.test(text), 'cumulative snapshots should not be appended wholesale');
+
+let deltaText = '';
+for (let i = 1; i <= 10; i += 1) {
+  deltaText = sandbox.appendReasoningText(deltaText, `token${i}`, sandbox.MAX_REASONING_STORED_CHARS);
+}
+assert.equal(deltaText, 'token1 token2 token3 token4 token5 token6 token7 token8 token9 token10');
+
+const rendered = sandbox.formatReasoningTextForRender('x'.repeat(sandbox.MAX_REASONING_RENDER_CHARS + 500));
+assert.ok(rendered.length < sandbox.MAX_REASONING_RENDER_CHARS + 200);
+assert.ok(rendered.startsWith('[showing latest reasoning notes; earlier notes were compacted]'));
+
+console.log('Reasoning notes compaction tests passed');


### PR DESCRIPTION
## Summary
- Normalize cumulative reasoning snapshots into deltas so Reasoning Notes do not grow quadratically.
- Cap stored/rendered live reasoning notes to a bounded tail.
- Avoid full conversation mirror writes on every live reasoning event; final stream sync still persists the completed turn.
- Bump Hermes UI to v3.3.26 with release notes.
- Add a Node regression test for cumulative reasoning snapshots.

## Verification
- node tests/reasoning_notes_compaction.mjs
- python3 -m py_compile serve_lite.py tests/browser_conversation_compaction.py tests/browser_smoke.py tests/update_repo_logic.py
- python3 tests/update_repo_logic.py
- /tmp/hermes-ui-playwright-venv/bin/python tests/browser_smoke.py
- /tmp/hermes-ui-playwright-venv/bin/python tests/browser_conversation_compaction.py

Fixes #29